### PR TITLE
Send actions to server

### DIFF
--- a/server/reducer.js
+++ b/server/reducer.js
@@ -6,10 +6,31 @@ function setState(state, newState) {
   return state.merge(newState);
 }
 
+function toggleOrder(state, orderId) {
+  const orders = state.get('orders');
+  const orderIndex = orders.findIndex((order) => {
+    return order.get('id') === orderId;
+  });
+
+  return state.updateIn(
+    ['orders'],
+    orders,
+    (orders) => orders.update(
+      orderIndex,
+      (order) => order.updateIn(
+        ['status'],
+        'open',
+        (status) => status === 'open' ? 'closed' : 'open'
+      )
+    ));
+}
+
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
   case 'SET_STATE':
     return setState(state, action.state);
+  case 'TOGGLE_ORDER':
+    return toggleOrder(state, action.orderId);
   }
   return state;
 }

--- a/src/action_creators.js
+++ b/src/action_creators.js
@@ -7,6 +7,7 @@ export function setState(state) {
 
 export function toggleOrder(orderId) {
   return {
+    meta: { remote: true },
     type: 'TOGGLE_ORDER',
     orderId: orderId
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
-import React               from 'react';
-import ReactDOM            from 'react-dom';
-import { Router, Route }   from 'react-router';
-import { createStore }     from 'redux';
-import { Provider }        from 'react-redux';
-import reducer             from './reducer';
-import { setState }        from './action_creators';
-import App                 from './components/App';
-import { OrdersContainer } from './components/Orders';
-import Hello               from './components/Hello';
-import io                  from 'socket.io-client';
+import React                            from 'react';
+import ReactDOM                         from 'react-dom';
+import { Router, Route }                from 'react-router';
+import { createStore, applyMiddleware } from 'redux';
+import { Provider }                     from 'react-redux';
+import reducer                          from './reducer';
+import { setState }                     from './action_creators';
+import remoteActionMiddleware           from './remote_action_middleware';
+import App                              from './components/App';
+import { OrdersContainer }              from './components/Orders';
+import Hello                            from './components/Hello';
+import io                               from 'socket.io-client';
 
 require('./style.css');
 
@@ -16,7 +17,8 @@ const router   = React.createFactory(Router);
 const route    = React.createFactory(Route);
 const provider = React.createFactory(Provider);
 
-const store = createStore(reducer);
+const createStoreWithMiddleware = applyMiddleware(remoteActionMiddleware)(createStore);
+const store = createStoreWithMiddleware(reducer);
 const thisDocument = window.document;
 const port = thisDocument.location.hostname === 'localhost' ? ':3000' : '';
 const location = `${thisDocument.location.protocol}//${thisDocument.location.hostname}${port}`;

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,15 @@ const router   = React.createFactory(Router);
 const route    = React.createFactory(Route);
 const provider = React.createFactory(Provider);
 
-const createStoreWithMiddleware = applyMiddleware(remoteActionMiddleware)(createStore);
-const store = createStoreWithMiddleware(reducer);
 const thisDocument = window.document;
 const port = thisDocument.location.hostname === 'localhost' ? ':3000' : '';
 const location = `${thisDocument.location.protocol}//${thisDocument.location.hostname}${port}`;
 const socket = io.connect(location);
+const createStoreWithMiddleware = applyMiddleware(
+  remoteActionMiddleware(socket)
+)(createStore);
+const store = createStoreWithMiddleware(reducer);
+
 socket.on('connected', (data) => console.log(data));
 socket.on('state', (state) => store.dispatch(setState(state)));
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,4 +1,4 @@
-import { List, Map } from 'immutable';
+import { Map } from 'immutable';
 
 const INITIAL_STATE = Map();
 
@@ -6,31 +6,10 @@ function setState(state, newState) {
   return state.merge(newState);
 }
 
-function toggleOrder(state, orderId) {
-  const orders = state.get('orders');
-  const orderIndex = orders.findIndex((order) => {
-    return order.get('id') === orderId;
-  });
-
-  return state.updateIn(
-    ['orders'],
-    orders,
-    (orders) => orders.update(
-      orderIndex,
-      (order) => order.updateIn(
-        ['status'],
-        'open',
-        (status) => status === 'open' ? 'closed' : 'open'
-      )
-    ));
-}
-
 export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
   case 'SET_STATE':
     return setState(state, action.state);
-  case 'TOGGLE_ORDER':
-    return toggleOrder(state, action.orderId);
   }
   return state;
 }

--- a/src/remote_action_middleware.js
+++ b/src/remote_action_middleware.js
@@ -1,0 +1,4 @@
+export default (store) => (next) => (action) => {
+  console.log('from middleware', action);
+  return next(action);
+}

--- a/src/remote_action_middleware.js
+++ b/src/remote_action_middleware.js
@@ -1,4 +1,6 @@
-export default (store) => (next) => (action) => {
-  console.log('from middleware', action);
+export default (socket) => (store) => (next) => (action) => {
+  if (action.meta && action.meta.remote) {
+    socket.emit('action', action);
+  }
   return next(action);
 }

--- a/test/reducer_spec.js
+++ b/test/reducer_spec.js
@@ -70,22 +70,4 @@ describe('reducer', () => {
       }));
     });
   });
-
-  describe('TOGGLE_ORDER', () => {
-    it('is handled', () => {
-      const order = Map({ id: 1, status: 'open' });
-      const initialState = Map({
-        orders: List.of(order)
-      });
-      const action = {
-        type: 'TOGGLE_ORDER',
-        orderId: 1
-      };
-      const nextState = reducer(initialState, action);
-
-      expect(nextState).to.equal(fromJS({
-        orders: [{ id: 1, status: 'closed' }]
-      }));
-    });
-  });
 });


### PR DESCRIPTION
Ended up adding this 'middleware' to intercept and synthesize actions created on the client before passing off to the server. Currently, for the demo action TOGGLE_ORDER, the client doesn't actually handle itself. Instead, it relies on the server to handle and emit an updated state back to the client. 

Considerations:
1. Seems expensive to pass entire app state back and forth on every action / event, but I think Immutable and React are smart / efficient enough to make it okay..
2. If multiple clients connect to the socket server, they share the same instance of the server / app right? Meaning, we do need a server store to keep the app state updated in realtime to all clients?
