### PR TITLE
Remove redundant eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,6 @@
   "engines": {
     "node": "0.10.x"
   },
-  "eslintConfig": {
-    "rules": {
-      "camelcase": [2, {"properties": "never"}]
-    }
-  },
   "pre-commit": [
     "lint",
     "test"


### PR DESCRIPTION
We don't need this anymore because you added to `.eslintrc` right?
