### PR TITLE
Fix go script syntax

### DIFF
--- a/go
+++ b/go
@@ -21,8 +21,7 @@ client() {
 
 server() {
   key="$1"
-  if [ $key == '-d' ] || [ $key == '--debug' ]
-  then
+  if [ "$key" = "-d" ] || [ "$key" = "--debug" ]; then
     echo "Starting server - debug mode"
     node_modules/iron-node/bin/run.js debug.js
   else


### PR DESCRIPTION
Was getting this when running without debug flag:

```
pos $ ./go server
./go: line 24: [: ==: unary operator expected 
```
