### PR TITLE
Improve payments form

### DIFF
--- a/src/components/Payment.js
+++ b/src/components/Payment.js
@@ -13,7 +13,7 @@ class Payment extends Component {
     return (
       dom.div(
         { className: 'payment-component' },
-        dom.h2({ className: 'payment-component-heading' }, 'Amounts Paid'),
+        dom.h2({ className: 'payment-component-heading' }, 'Payment Information'),
         this.props.orderStatus === constants.READY_FOR_BILL ?
           PaymentForm(_.extend({}, this.props.transaction, {
             setClosed: this.props.setClosed,

--- a/src/money.js
+++ b/src/money.js
@@ -5,11 +5,11 @@ function format(amount) {
 }
 
 function cents(dollars) {
-  return accounting.toFixed(dollars * 100, 0);
+  return parseInt(accounting.toFixed(dollars * 100, 0));
 }
 
 function dollars(cents) {
-  return accounting.toFixed(cents / 100, 2);
+  return parseFloat(accounting.toFixed(cents / 100, 2));
 }
 
 export default {

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 function labelForField(field) {
   return {
-    cash: 'Cash',
-    credit: 'Credit',
+    cash: 'Paid in Cash',
+    credit: 'Paid in Credit',
     tip: 'Tip in Credit'
   }[field];
 }

--- a/test/components/PaymentForm_spec.js
+++ b/test/components/PaymentForm_spec.js
@@ -24,8 +24,6 @@ function setup({ cash = 0, credit = 0, tip = 0 } = {}) {
 
   return {
     component,
-    balance: findRenderedDOMComponentWithClass(component, 'payment-balance-amount'),
-    cashInput: findRenderedDOMComponentWithClass(component, 'cash-amount-input'),
     creditInput: findRenderedDOMComponentWithClass(component, 'credit-amount-input'),
     tipInput: findRenderedDOMComponentWithClass(component, 'tip-amount-input'),
     startingBalance
@@ -35,39 +33,11 @@ function setup({ cash = 0, credit = 0, tip = 0 } = {}) {
 describe('PaymentForm', () => {
   const setClosed = () => {};
 
-  it('renders balance remaining after entered amounts', () => {
-    const { component, balance, cashInput, startingBalance } = setup();
-
-    expect(balance.textContent).to.contain($.format(startingBalance));
-
-    const amount = 5;
-    cashInput.value = amount;
-    Simulate.change(cashInput);
-
-    expect(balance.textContent).to.contain($.format(startingBalance - $.cents(amount)));
-  });
-
-  it('does not include credit tip amount when calculating remaining balance', () => {
-    const { component, balance, cashInput, tipInput, startingBalance } = setup();
-
-    expect(balance.textContent).to.contain($.format(startingBalance));
-
-    const amount = 5;
-    tipInput.value = amount;
-    Simulate.change(tipInput);
-
-    cashInput.value = 0;
-    Simulate.change(cashInput);
-
-    expect(balance.textContent).to.contain($.format(startingBalance));
-  });
-
   it('prefills input fields with zero if no existing transaction amounts', () => {
-    const { component, balance, cashInput, creditInput, tipInput } = setup();
+    const { component, creditInput, tipInput } = setup();
 
-    expect(cashInput.value).to.eq($.dollars(0));
-    expect(creditInput.value).to.eq($.dollars(0));
-    expect(tipInput.value).to.eq($.dollars(0));
+    expect(creditInput.attributes.placeholder.value).to.eq('0');
+    expect(tipInput.attributes.placeholder.value).to.eq('0');
   });
 
   it('prefills input fields with existing transaction amounts', () => {
@@ -75,11 +45,10 @@ describe('PaymentForm', () => {
     const credit = 2000;
     const tip = 500;
     const existing = { cash, credit, tip };
-    const { component, balance, cashInput, creditInput, tipInput, startingBalance } = setup(existing);
+    const { component, creditInput, tipInput, startingBalance } = setup(existing);
 
-    expect(cashInput.value).to.eq($.dollars(cash));
-    expect(creditInput.value).to.eq($.dollars(credit));
-    expect(tipInput.value).to.eq($.dollars(tip));
+    expect(creditInput.attributes.placeholder.value).to.eq($.dollars(credit).toString());
+    expect(tipInput.attributes.placeholder.value).to.eq($.dollars(tip).toString());
   });
 });
 


### PR DESCRIPTION
Made changes based on our discussion. May want to further discuss / think about the 'All Paid in Cash' button though--do you think it could be confusing? Would it be better / worse to just make it a single button and have the text change based on amounts entered? Also, not doing any validation before closing the order now, since we're just plugging the cash amount. Shouldn't really be an issue though, unless they mistakenly enter a credit amount greater than the total?
