### PR TITLE
Make FilterComponent props more generic

### DIFF
--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -42,6 +42,7 @@ class Filter extends Component {
 }
 
 Filter.propTypes = {
+  filter: PropTypes.string.isRequired,
   filters: PropTypes.array.isRequired,
   applyFilter: PropTypes.func.isRequired,
   printFilterName: PropTypes.func

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -1,6 +1,7 @@
 import { Component, PropTypes, DOM as dom } from 'react';
 import actions from '../action_creators';
 import constants from '../constants';
+import _ from 'ramda';
 
 class Filter extends Component {
   constructor(props) {
@@ -22,9 +23,9 @@ class Filter extends Component {
             `filter-option filter-${normalized}`,
             `btn ${this.isSelectedFilter(filter)} text-capitalize`
           ].join(' '),
-          onClick: () => this.props.filterOrders(filter)
+          onClick: () => this.props.applyFilter(filter)
         },
-        this.props.printOrderStatus(filter)
+        this.props.printFilterName(filter)
       )
     );
   }
@@ -41,8 +42,13 @@ class Filter extends Component {
 }
 
 Filter.propTypes = {
-  filterOrders: PropTypes.func.isRequired,
-  filters: PropTypes.array.isRequired
+  filters: PropTypes.array.isRequired,
+  applyFilter: PropTypes.func.isRequired,
+  printFilterName: PropTypes.func
+};
+
+Filter.defaultProps = {
+  printFilterName: _.identity
 };
 
 export default Filter;

--- a/src/components/OpenOrder.js
+++ b/src/components/OpenOrder.js
@@ -72,9 +72,9 @@ class OpenOrder extends Component {
             Filter(
               {
                 filter,
-                filterOrders: this.filterOrders,
-                printOrderStatus: this.printOrderStatus,
-                filters: [constants.ALL, constants.FOOD, constants.DRINK]
+                filters: [constants.ALL, constants.FOOD, constants.DRINK],
+                applyFilter: this.filterOrders,
+                printFilterName: this.printOrderStatus
               }
             ),
           )

--- a/src/components/Orders.js
+++ b/src/components/Orders.js
@@ -66,9 +66,9 @@ class Orders extends Component {
             Filter(
               {
                 filter: this.state.filter,
-                filterOrders: this.filterOrders,
-                printOrderStatus: this.printOrderStatus,
-                filters: [constants.OPEN, constants.READY_FOR_BILL, constants.ALL]
+                filters: [constants.OPEN, constants.READY_FOR_BILL, constants.ALL],
+                applyFilter: this.filterOrders,
+                printFilterName: this.printOrderStatus
               }
             ),
           ),

--- a/test/components/Filter_spec.js
+++ b/test/components/Filter_spec.js
@@ -15,12 +15,13 @@ const {
 const Filter = React.createFactory(FilterComponent);
 
 describe('Filter', () => {
+  const filter = constants.ALL;
   const printFilterName = (status) => {};
   const filters = [constants.OPEN, constants.READY_FOR_BILL, constants.ALL];
 
   it('renders filter options from props', () => {
     const applyFilter = () => {};
-    const component = renderIntoDocument(Filter({ applyFilter, printFilterName, filters }));
+    const component = renderIntoDocument(Filter({ filter, applyFilter, printFilterName, filters }));
     const filterOptions = scryRenderedDOMComponentsWithClass(component, 'filter-option');
 
     expect(filterOptions.length).to.equal(3);
@@ -43,7 +44,7 @@ describe('Filter', () => {
         calledWithReady = true;
       }
     };
-    const component = renderIntoDocument(Filter({ applyFilter, printFilterName, filters }));
+    const component = renderIntoDocument(Filter({ filter, applyFilter, printFilterName, filters }));
     const filterOptions = scryRenderedDOMComponentsWithClass(component, 'filter-option');
     Simulate.click(filterOptions[0]);
     Simulate.click(filterOptions[1]);

--- a/test/components/Filter_spec.js
+++ b/test/components/Filter_spec.js
@@ -15,12 +15,12 @@ const {
 const Filter = React.createFactory(FilterComponent);
 
 describe('Filter', () => {
-  const printOrderStatus = (status) => {};
+  const printFilterName = (status) => {};
   const filters = [constants.OPEN, constants.READY_FOR_BILL, constants.ALL];
 
   it('renders filter options from props', () => {
-    const filterOrders = () => {};
-    const component = renderIntoDocument(Filter({ filterOrders, printOrderStatus, filters }));
+    const applyFilter = () => {};
+    const component = renderIntoDocument(Filter({ applyFilter, printFilterName, filters }));
     const filterOptions = scryRenderedDOMComponentsWithClass(component, 'filter-option');
 
     expect(filterOptions.length).to.equal(3);
@@ -33,7 +33,7 @@ describe('Filter', () => {
     let calledWithAll = false;
     let calledWithOpen = false;
     let calledWithReady = false;
-    const filterOrders = (filter) => {
+    const applyFilter = (filter) => {
       switch (filter) {
       case constants.ALL:
         calledWithAll = true;
@@ -43,7 +43,7 @@ describe('Filter', () => {
         calledWithReady = true;
       }
     };
-    const component = renderIntoDocument(Filter({ filterOrders, printOrderStatus, filters }));
+    const component = renderIntoDocument(Filter({ applyFilter, printFilterName, filters }));
     const filterOptions = scryRenderedDOMComponentsWithClass(component, 'filter-option');
     Simulate.click(filterOptions[0]);
     Simulate.click(filterOptions[1]);


### PR DESCRIPTION
To be used for things other than orders (entries, payments, dates, etc.).
