### PR TITLE
Set isLoading to true on the client

### DIFF
--- a/server/action_creators.js
+++ b/server/action_creators.js
@@ -28,7 +28,6 @@ export function updateOrder(orderId, order) {
 
 export function getInitialState() {
   return (dispatch, getState) => {
-    dispatch(isLoading());
     const getItems = () => Item.find().sort('category');
     const getDiscounts = () => Discount.find();
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -13,6 +13,8 @@ export default function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
   case constants.SET_STATE:
     return setState(state, action.state);
+  case constants.GET_INITIAL_STATE:
+    return setState(state, { isLoading: true });
   case constants.SET_USER:
     const { user, token } = action;
     return setState(state, { user, token });


### PR DESCRIPTION
Just realized that older implementation sets isLoading on shared server state, so all client will get isLoading true when isLoading() is dispatched on the server. Instead I just set loading to true on client side.
